### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@huggingface/hub": "1.1.2",
-    "hyperparam": "0.2.30",
-    "hightable": "0.13.3",
+    "hyperparam": "0.2.31",
+    "hightable": "0.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },


### PR DESCRIPTION
Requires https://github.com/hyparam/hightable/pull/97 + https://github.com/hyparam/hyperparam-cli/pull/201 before (tests are failing meanwhile because 0.13.4 and 0.2.31 have not been published yet).